### PR TITLE
Add python-setuptools as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Team Kano <dev@kano.me>
 Section: games
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0)
+Build-Depends: debhelper (>=9.0.0), python-setuptools
 
 Package: linux-story
 Architecture: all


### PR DESCRIPTION
Adding this ensures that the package is built more reliably