### PR TITLE
Fix some formatting issues introduced during internationalisation.

### DIFF
--- a/linux_story/story/challenges/challenge_19.py
+++ b/linux_story/story/challenges/challenge_19.py
@@ -98,8 +98,8 @@ class Step2(StepTemplateEcho):
 
         if self.last_user_input.lower() in replies:
             hint = [
-                _("\n{{rb:If you want to reply with \"{}\", use}} {{yb:echo {}}}") \
-                        .format(self.last_user_input, replies[self.last_user_input.lower()])
+                _("\n{{rb:If you want to reply with \"%s\", use}} {{yb:echo %s}}") \
+                        % (self.last_user_input, replies[self.last_user_input.lower()])
             ]
             self.send_text(hint)
         else:

--- a/linux_story/story/challenges/challenge_21.py
+++ b/linux_story/story/challenges/challenge_21.py
@@ -342,7 +342,7 @@ class Step9(StepTemplateMkdir):
         end_dir_validated = False
         self.hints = [
             _("{{rb:Use}} {{yb:%s}} {{rb:to progress}}") \
-                    .format(self.all_commands[0])
+                    % (self.all_commands[0],)
         ]
 
         end_dir_validated = self.current_path == self.end_dir
@@ -365,7 +365,7 @@ class Step9(StepTemplateMkdir):
                     " {{yb:.shelter}}")
                 )
             elif len(self.all_commands) > 0:
-                hint = _("\n{{gb:Well done! Move %d more.}}")\
+                hint = _("\n{{gb:Well done! Move %s more.}}")\
                     % str(len(self.all_commands) / 2)
             else:
                 hint = _("\n{{gb:Press}} {{ob:Enter}} {{gb:to continue}}")


### PR DESCRIPTION
For https://github.com/KanoComputing/peldins/issues/2429
This is a couple of fixes for bugs introduced in https://github.com/KanoComputing/terminal-quest/pull/64
We can't used `.format` where terminal-quest's '{{}}" codes are in use.
@tombettany @radujipa 