### PR TITLE
…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Maintainer: Team Kano <dev@kano.me>
 Section: games
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0), python-setuptools, gettext
+Build-Depends: debhelper (>=9.0.0), python-setuptools, gettext, python
 
 Package: linux-story
 Architecture: all
 Depends: ${misc:Depends}, python (>=2.7), gir1.2-vte-2.90,
- kano-profile (>=1.3-6), kano-toolset (>=2.4.0-1), kano-i18n
+ kano-profile (>=1.3-6), kano-toolset (>=2.4.0-1), kano-i18n, python
 Description: Story to teach people basic Linux commands
  via a text based adventure game style.
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,9 +1,10 @@
 #!/usr/bin/make -f
 
+export PYBUILD_DESTDIR=debian/linux-story/
 %:
 	cd po && make messages.pot
 	cd po && make
-	dh $@ --with python2
+	dh $@ --with python2  --buildsystem=pybuild
 
 override_dh_python2:
 	dh_python2 --no-shebang-rewrite


### PR DESCRIPTION
Now we are exporting multiple binary packages, we seem to need to use pybuild if we want to use
setup.py. Pybuild needs an explicit destdir otherwise it prepends 'python-' to the package name.
Pybuild also uses the depends field to detect which python version to use.
@skarbat @tombettany 