### PR TITLE
Fixed hint not showing for challenge 39 step 4

### DIFF
--- a/linux_story/story/challenges/challenge_39.py
+++ b/linux_story/story/challenges/challenge_39.py
@@ -125,7 +125,6 @@ class Step4(StepTemplateChmod):
             self.send_hint(
                 _("Swordmaster: {{Bb:\"That's a strange name. Is that really your name?\"}}")
             )
-            return
         return StepTemplateChmod.check_command(self, last_user_input)
 
     def next(self):


### PR DESCRIPTION
At this point in the story, the player is chatting to the Swordmaster
whom asks for the linux user name. The issue here is that the hint
helping users what to type was not working because of a misplaced
return statement.

![kano-screenshot-wed-aug-30-17-24-39](https://user-images.githubusercontent.com/3577547/29883440-3c13ac94-8da8-11e7-9f82-886597313579.png)