### PR TITLE
Bumped changelog for 3.9.1 version of es_AR

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-story (3.9.1-0) unstable; urgency=low
+
+  * i18n: Add updated es_AR translations and fixes (backport)
+  * Fix app shortcut to acquire interactive shell environment (backport)
+
+ -- Team Kano <dev@kano.me>  Fri, 21 Jul 2017 13:48:50 +0001
+
 linux-story (1.2-1) unstable; urgency=low
 
   * Initial release.


### PR DESCRIPTION
This bumps the version of the package for the es_AR image.