### PR TITLE
Update changelog forwardports

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-story (3.14.0-0) unstable; urgency=low
+
+  * Applied changes from v3.9.1 es_AR backports to latest
+
+ -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
+
 linux-story (3.9.1-0) unstable; urgency=low
 
   * i18n: Add updated es_AR translations and fixes (backport)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-story (3.9.1-0) unstable; urgency=low
+
+  * i18n: Add updated es_AR translations and fixes (backport)
+  * Fix app shortcut to acquire interactive shell environment (backport)
+
+ -- Team Kano <dev@kano.me>  Fri, 21 Jul 2017 13:48:50 +0001
+
 linux-story (1.2-1) unstable; urgency=low
 
   * Initial release.


### PR DESCRIPTION
This is the application of https://github.com/KanoComputing/terminal-quest/pull/91 to master and also the version bump for 3.14.0. This is to specify that the changes made in the es_AR image need to be rebuilt, tested, and released from master as well.